### PR TITLE
More cleanup & fixes

### DIFF
--- a/src/GameController/GameEngine.cs
+++ b/src/GameController/GameEngine.cs
@@ -58,6 +58,10 @@ public class GameEngine(IGrainFactory grainFactory, ILogger<GameEngine> logger) 
             catch (Exception ex)
             {
                 logger.LogError(ex, "RPO: GameEngine error.");
+                if (!stoppingToken.IsCancellationRequested)
+                {
+                    await Task.Delay(delay, stoppingToken);
+                }
             }
         }
     }

--- a/src/GameController/GameEngine.cs
+++ b/src/GameController/GameEngine.cs
@@ -57,9 +57,9 @@ public class GameEngine(IGrainFactory grainFactory, ILogger<GameEngine> logger) 
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "RPO: GameEngine error.");
                 if (!stoppingToken.IsCancellationRequested)
                 {
+                    logger.LogError(ex, "RPO: GameEngine error.");
                     await Task.Delay(delay, stoppingToken);
                 }
             }

--- a/src/Infrastructure/PlayerWorker.cs
+++ b/src/Infrastructure/PlayerWorker.cs
@@ -1,36 +1,32 @@
 ﻿namespace RockPaperOrleans;
 
 public sealed class PlayerWorker<TPlayer>(IGrainFactory grainFactory, ILogger<PlayerWorker<TPlayer>> logger) 
-    : IHostedService where TPlayer : IPlayerGrain
+    : BackgroundService where TPlayer : IPlayerGrain
 {
-    public IPlayerSessionGrain? PlayerSessionGrain { get; set; }
-    public IPlayerGrain? PlayerGrain { get; set; }
-    public IGrainFactory GrainFactory { get; set; } = grainFactory;
-
-    public async Task StartAsync(CancellationToken cancellationToken)
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
-        while (true)
+        var playerSessionGrain = grainFactory.GetGrain<IPlayerSessionGrain>(typeof(TPlayer).Name);
+        var playerGrain = grainFactory.GetGrain<IPlayerGrain>(typeof(TPlayer).Name, grainClassNamePrefix: typeof(TPlayer).Name);
+        while (!stoppingToken.IsCancellationRequested)
         {
             try
             {
-                PlayerSessionGrain = GrainFactory.GetGrain<IPlayerSessionGrain>(typeof(TPlayer).Name);
-                PlayerGrain = GrainFactory.GetGrain<IPlayerGrain>(typeof(TPlayer).Name, grainClassNamePrefix: typeof(TPlayer).Name);
-                await PlayerSessionGrain.SignIn(PlayerGrain).ConfigureAwait(false);
-                return;
+                await playerSessionGrain.SignIn(playerGrain).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
             }
             catch (Exception ex)
             {
                 logger.LogError(ex, "Error registering player {PlayerType}.", typeof(TPlayer));
-                await Task.Delay(1000, cancellationToken);
+                if (!stoppingToken.IsCancellationRequested)
+                {
+                    await Task.Delay(1000, stoppingToken);
+                }
             }
         }
-    }
 
-    public async Task StopAsync(CancellationToken cancellationToken)
-    {
-        if (PlayerSessionGrain is not null)
+        if (playerSessionGrain is not null)
         {
-            await PlayerSessionGrain.SignOut().ConfigureAwait(false);
+            await playerSessionGrain.SignOut().ConfigureAwait(false);
         }
     }
 }

--- a/src/Infrastructure/PlayerWorker.cs
+++ b/src/Infrastructure/PlayerWorker.cs
@@ -19,7 +19,7 @@ public sealed class PlayerWorker<TPlayer>(IGrainFactory grainFactory, ILogger<Pl
                 if (!stoppingToken.IsCancellationRequested)
                 {
                     logger.LogError(ex, "Error registering player {PlayerType}.", typeof(TPlayer));
-                    await Task.Delay(1000, stoppingToken);
+                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
                 }
             }
         }

--- a/src/Infrastructure/PlayerWorker.cs
+++ b/src/Infrastructure/PlayerWorker.cs
@@ -16,9 +16,9 @@ public sealed class PlayerWorker<TPlayer>(IGrainFactory grainFactory, ILogger<Pl
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "Error registering player {PlayerType}.", typeof(TPlayer));
                 if (!stoppingToken.IsCancellationRequested)
                 {
+                    logger.LogError(ex, "Error registering player {PlayerType}.", typeof(TPlayer));
                     await Task.Delay(1000, stoppingToken);
                 }
             }

--- a/src/Leaderboard/Program.cs
+++ b/src/Leaderboard/Program.cs
@@ -50,7 +50,7 @@ public class LeaderboardObserverWorker(
                 if (!stoppingToken.IsCancellationRequested)
                 {
                     logger.LogError(ex, "RPO: LeaderboardObserverWorker error.");
-                    await Task.Delay(1000, stoppingToken);
+                    await Task.Delay(TimeSpan.FromSeconds(1), stoppingToken);
                 }
             }
         }

--- a/src/Leaderboard/Program.cs
+++ b/src/Leaderboard/Program.cs
@@ -47,9 +47,9 @@ public class LeaderboardObserverWorker(
             }
             catch (Exception ex)
             {
-                logger.LogError(ex, "RPO: LeaderboardObserverWorker error.");
                 if (!stoppingToken.IsCancellationRequested)
                 {
+                    logger.LogError(ex, "RPO: LeaderboardObserverWorker error.");
                     await Task.Delay(1000, stoppingToken);
                 }
             }

--- a/src/RockPaperOrleans.Abstractions/Extensions/GameExtensions.cs
+++ b/src/RockPaperOrleans.Abstractions/Extensions/GameExtensions.cs
@@ -6,7 +6,7 @@ public static class GameExtensions
     {
         try
         {
-            double pct = (double)player.WinCount / (double)player.TotalGamesPlayed;
+            double pct = player.WinCount / (double)player.TotalGamesPlayed;
             return Math.Round(pct * 100, 0);
         }
         catch

--- a/src/RockPaperOrleans.Abstractions/GrainInterfaces/IMatchmakingGrain.cs
+++ b/src/RockPaperOrleans.Abstractions/GrainInterfaces/IMatchmakingGrain.cs
@@ -2,5 +2,5 @@
 
 public interface IMatchmakingGrain : IGrainWithGuidKey
 {
-    Task<Tuple<Player, Player>?> ChoosePlayers();
+    Task<(Player One, Player Two)?> ChoosePlayers();
 }

--- a/src/RockPaperOrleans.Abstractions/Observers/IPlayerObserver.cs
+++ b/src/RockPaperOrleans.Abstractions/Observers/IPlayerObserver.cs
@@ -1,6 +1,0 @@
-﻿namespace RockPaperOrleans.Abstractions;
-
-public interface IPlayerObserver : IGrainObserver
-{
-    Task<Play> Go();
-}

--- a/src/RockPaperOrleans.Grains/LeaderboardGrain.cs
+++ b/src/RockPaperOrleans.Grains/LeaderboardGrain.cs
@@ -1,91 +1,66 @@
-﻿namespace RockPaperOrleans.Grains;
+﻿using Orleans.Utilities;
 
-public class LeaderboardGrain : Grain, ILeaderboardGrain
+namespace RockPaperOrleans.Grains;
+
+public class LeaderboardGrain(ILogger<LeaderboardGrain> logger) : Grain, ILeaderboardGrain
 {
-    private readonly HashSet<ILeaderboardGrainObserver> _observers = [];
+    private readonly ObserverManager<ILeaderboardGrainObserver> _observers = new(TimeSpan.FromMinutes(1), logger);
 
     public Task Subscribe(ILeaderboardGrainObserver observer)
     {
-        _observers.Add(observer);
+        _observers.Subscribe(observer, observer);
         return Task.CompletedTask;
     }
 
     public async Task GameStarted(Game game, Player player1, Player player2)
     {
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnGameStarted(game, player1, player2);
-        }
+        await _observers.Notify(observer => observer.OnGameStarted(game, player1, player2));
     }
 
     public async Task TurnStarted(Turn turn, Game game)
     {
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnTurnStarted(turn, game);
-        }
+        await _observers.Notify(observer => observer.OnTurnStarted(turn, game));
     }
 
     public async Task TurnCompleted(Turn turn, Game game)
     {
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnTurnCompleted(turn, game);
-        }
+        await _observers.Notify(observer => observer.OnTurnCompleted(turn, game));
     }
 
     public async Task TurnScored(Turn turn, Game game)
     {
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnTurnScored(turn, game);
-        }
+        await _observers.Notify(observer => observer.OnTurnScored(turn, game));
     }
 
     public async Task GameCompleted(Game game)
     {
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnGameCompleted(game);
-        }
+        await _observers.Notify(observer => observer.OnGameCompleted(game));
     }
 
     public Task UnSubscribe(ILeaderboardGrainObserver observer)
     {
-        _observers.Remove(observer);
+        _observers.Unsubscribe(observer);
         return Task.CompletedTask;
     }
 
     public async Task LobbyUpdated(List<Player> playersInLobby)
     {
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnLobbyUpdated(playersInLobby);
-        }
+        await _observers.Notify(observer => observer.OnLobbyUpdated(playersInLobby));
     }
 
     public async Task PlayersOnlineUpdated(List<Player> playersOnline)
     {
-        playersOnline = [.. playersOnline.OrderByDescending(x => x.PercentWon)];
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnPlayersOnlineUpdated(playersOnline);
-        }
+        List<Player> orderedPlayers = [.. playersOnline.OrderByDescending(x => x.PercentWon)];
+        await _observers.Notify(observer => observer.OnPlayersOnlineUpdated(orderedPlayers));
     }
 
     public async Task PlayerScoresUpdated(Player player)
     {
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnPlayerScoresUpdated(player);
-        }
+        await _observers.Notify(observer => observer.OnPlayerScoresUpdated(player));
     }
 
     public async Task UpdateSystemStatus(SystemStatusUpdate update)
     {
-        foreach (var leaderBoardObserver in _observers)
-        {
-            await leaderBoardObserver.OnSystemStatusUpdated(update);
-        }
+        await _observers.Notify(observer => observer.OnSystemStatusUpdated(update));
     }
 }

--- a/src/RockPaperOrleans.Grains/LeaderboardGrain.cs
+++ b/src/RockPaperOrleans.Grains/LeaderboardGrain.cs
@@ -2,28 +2,17 @@
 
 public class LeaderboardGrain : Grain, ILeaderboardGrain
 {
-    public HashSet<ILeaderboardGrainObserver> Observers { get; set; } = new();
-    public IManagementGrain? ManagementGrain { get; set; }
-
-    public override Task OnActivateAsync(CancellationToken cancellationToken)
-    {
-        ManagementGrain = GrainFactory.GetGrain<IManagementGrain>(0);
-        return Task.CompletedTask;
-    }
+    private readonly HashSet<ILeaderboardGrainObserver> _observers = [];
 
     public Task Subscribe(ILeaderboardGrainObserver observer)
     {
-        if (!Observers.Contains(observer))
-        {
-            Observers.Add(observer);
-        }
-
+        _observers.Add(observer);
         return Task.CompletedTask;
     }
 
     public async Task GameStarted(Game game, Player player1, Player player2)
     {
-        foreach (var leaderBoardObserver in Observers)
+        foreach (var leaderBoardObserver in _observers)
         {
             await leaderBoardObserver.OnGameStarted(game, player1, player2);
         }
@@ -31,7 +20,7 @@ public class LeaderboardGrain : Grain, ILeaderboardGrain
 
     public async Task TurnStarted(Turn turn, Game game)
     {
-        foreach (var leaderBoardObserver in Observers)
+        foreach (var leaderBoardObserver in _observers)
         {
             await leaderBoardObserver.OnTurnStarted(turn, game);
         }
@@ -39,7 +28,7 @@ public class LeaderboardGrain : Grain, ILeaderboardGrain
 
     public async Task TurnCompleted(Turn turn, Game game)
     {
-        foreach (var leaderBoardObserver in Observers)
+        foreach (var leaderBoardObserver in _observers)
         {
             await leaderBoardObserver.OnTurnCompleted(turn, game);
         }
@@ -47,7 +36,7 @@ public class LeaderboardGrain : Grain, ILeaderboardGrain
 
     public async Task TurnScored(Turn turn, Game game)
     {
-        foreach (var leaderBoardObserver in Observers)
+        foreach (var leaderBoardObserver in _observers)
         {
             await leaderBoardObserver.OnTurnScored(turn, game);
         }
@@ -55,7 +44,7 @@ public class LeaderboardGrain : Grain, ILeaderboardGrain
 
     public async Task GameCompleted(Game game)
     {
-        foreach (var leaderBoardObserver in Observers)
+        foreach (var leaderBoardObserver in _observers)
         {
             await leaderBoardObserver.OnGameCompleted(game);
         }
@@ -63,17 +52,13 @@ public class LeaderboardGrain : Grain, ILeaderboardGrain
 
     public Task UnSubscribe(ILeaderboardGrainObserver observer)
     {
-        if (Observers.Contains(observer))
-        {
-            Observers.Remove(observer);
-        }
-
+        _observers.Remove(observer);
         return Task.CompletedTask;
     }
 
     public async Task LobbyUpdated(List<Player> playersInLobby)
     {
-        foreach (var leaderBoardObserver in Observers)
+        foreach (var leaderBoardObserver in _observers)
         {
             await leaderBoardObserver.OnLobbyUpdated(playersInLobby);
         }
@@ -81,16 +66,16 @@ public class LeaderboardGrain : Grain, ILeaderboardGrain
 
     public async Task PlayersOnlineUpdated(List<Player> playersOnline)
     {
-        foreach (var leaderBoardObserver in Observers)
+        playersOnline = [.. playersOnline.OrderByDescending(x => x.PercentWon)];
+        foreach (var leaderBoardObserver in _observers)
         {
-            playersOnline = playersOnline.OrderByDescending(x => x.PercentWon).ToList();
             await leaderBoardObserver.OnPlayersOnlineUpdated(playersOnline);
         }
     }
 
     public async Task PlayerScoresUpdated(Player player)
     {
-        foreach (var leaderBoardObserver in Observers)
+        foreach (var leaderBoardObserver in _observers)
         {
             await leaderBoardObserver.OnPlayerScoresUpdated(player);
         }
@@ -98,7 +83,7 @@ public class LeaderboardGrain : Grain, ILeaderboardGrain
 
     public async Task UpdateSystemStatus(SystemStatusUpdate update)
     {
-        foreach (var leaderBoardObserver in Observers)
+        foreach (var leaderBoardObserver in _observers)
         {
             await leaderBoardObserver.OnSystemStatusUpdated(update);
         }

--- a/src/RockPaperOrleans.Grains/PlayerSessionGrain.cs
+++ b/src/RockPaperOrleans.Grains/PlayerSessionGrain.cs
@@ -28,15 +28,17 @@ public class PlayerSessionGrain(
 
     public async Task SignIn(IPlayerGrain playerGrain)
     {
-        logger.LogInformation("RPO: Player {PlayerName} has signed in in to play.", player.State.Name);
-
-        _playerGrain = playerGrain;
-        player.State.IsActive = true;
+        if (!playerGrain.Equals(_playerGrain))
+        {
+            logger.LogInformation("RPO: Player {PlayerName} has signed in in to play.", player.State.Name);
+            _playerGrain = playerGrain;
+            player.State.IsActive = true;
+            await player.WriteStateAsync();
+        }
 
         var lobbyGrain = GrainFactory.GetGrain<ILobbyGrain>(Guid.Empty);
         await lobbyGrain.SignIn(player.State);
         await lobbyGrain.EnterLobby(player.State);
-        await player.WriteStateAsync();
     }
 
     public async Task SignOut()


### PR DESCRIPTION
* Remove unused IPlayerObserver type
* Use ValueTuple with named elements
* Use primary constructor
* Fix duplicate state name in lobby
* Remove unnecessary properties
* Improve reliability of `IHostedService` implementations: they ought to survive cluster restarts correctly now.